### PR TITLE
docs: Add Marketing Website to Roadmap

### DIFF
--- a/docs/PRODUCT_ROADMAP.md
+++ b/docs/PRODUCT_ROADMAP.md
@@ -30,6 +30,7 @@ The modern web is cluttered with opaque identifiers: shortened links (`bit.ly/xy
 *   [x] **Security Audit:** Harden the system against SSRF and XSS (Issue #10, #33).
 *   [x] **Observability:** Structured JSON logging for Cloud Run (Issue #15).
 *   [x] **DevEx:** Comprehensive Makefile targets (Issue #16).
+*   [ ] **Project README:** Comprehensive getting started guide and architecture docs (Issue #41).
 *   [x] **Collaboration Strategy:** Define how agents and humans work together (Issue #12).
 
 ### Phase 2: The "Universal" Pivot (Current Focus)


### PR DESCRIPTION
Adds the task to build a simple marketing website (Issue #39) to Phase 2 of the roadmap.

This site will serve as the public face of LinkLens, featuring a live demo and download instructions.